### PR TITLE
ci: fix latest tag, tag ordering, and digest reference

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # metadata-action's latest=auto needs all tags visible to
+          # decide whether the current ref is the highest semver.
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -56,15 +60,33 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # latest=auto: :latest only when pushing the highest semver
+          # tag. Manual dispatch (raw value) won't touch :latest.
+          flavor: |
+            latest=auto
           # Tag push: semver pattern strips the 'v' → :0.1.0.
           # Manual:   use the input verbatim → :<whatever-you-typed>.
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=raw,value=latest
+
+      # Manual dispatch only — tag pushes already carry the git tag.
+      # GITHUB_TOKEN-pushed tags don't re-trigger this workflow
+      # (GitHub policy). Runs BEFORE the build so a duplicate tag
+      # fails fast without publishing an orphan image.
+      - name: Push git tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "v$TAG" "$GITHUB_SHA" -m "Release v$TAG"
+          git push origin "v$TAG"
 
       - name: Build and push Dockery image
-        uses: docker/build-push-action@v5
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile
@@ -77,22 +99,9 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
-      # Manual dispatch only — tag pushes already carry the git tag.
-      # GITHUB_TOKEN-pushed tags don't re-trigger this workflow
-      # (GitHub policy). git push fails loudly if the tag exists.
-      - name: Push git tag
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          TAG: ${{ inputs.tag }}
-        run: |
-          git config user.name  'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git tag -a "v$TAG" "$GITHUB_SHA" -m "Release v$TAG"
-          git push origin "v$TAG"
-
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.meta.outputs.digest }}
+          subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
- fetch-depth: 0 so metadata-action can resolve highest semver
- Switch to latest=auto; drop unconditional raw latest tag
- Move git tag push before build to fail fast on duplicates
- Upgrade build-push-action v5→v6
- Fix attestation digest to use build step output