### PR TITLE
ci: add PR validation workflow + clear lint debt + doc fixups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+# Validates every PR and every push to main/dev. The release workflow
+# (build-and-push.yml) only fires on tags, so this is the gate that
+# actually runs tests/lint/build before code reaches main.
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  web-ui:
+    name: web-ui · lint / test / build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: apps/web-ui
+    steps:
+      - uses: actions/checkout@v4
+
+      # pnpm before setup-node so the node cache can resolve the pnpm store.
+      # Version 9 matches docker/Dockerfile's ui-builder stage.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: apps/web-ui/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      # vitest auto-runs once (no watch) because GitHub Actions sets CI=true.
+      - run: pnpm test
+      # APP_VERSION is optional here — vite.config.ts falls back to 'dev'
+      # (the build-arg requirement is enforced only in the Docker build).
+      - run: pnpm build
+
+  api:
+    name: api · build / vet / test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/api/go.mod
+          cache-dependency-path: apps/api/go.sum
+
+      - run: go build ./...
+      - run: go vet ./...
+      # `make test` runs the suite minus the ent-generated package.
+      - run: make test

--- a/apps/web-ui/eslint.config.js
+++ b/apps/web-ui/eslint.config.js
@@ -20,4 +20,15 @@ export default defineConfig([
       globals: globals.browser,
     },
   },
+  {
+    // shadcn/ui primitives are generated and co-export a cva() `*Variants`
+    // constant next to the component (e.g. button.tsx → buttonVariants),
+    // which trips the Fast Refresh rule. Fast Refresh purity is irrelevant
+    // for generated primitives, so scope the rule off for that dir only —
+    // it stays strict everywhere else, and survives `pnpm ui` regen.
+    files: ['**/components/ui/**'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ])

--- a/apps/web-ui/src/__tests__/setup.ts
+++ b/apps/web-ui/src/__tests__/setup.ts
@@ -23,7 +23,6 @@ Object.defineProperty(window, 'matchMedia', {
 })
 
 // Mock IntersectionObserver
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 globalThis.IntersectionObserver = class IntersectionObserver {
   constructor() {}
   disconnect() {}
@@ -32,4 +31,5 @@ globalThis.IntersectionObserver = class IntersectionObserver {
     return []
   }
   unobserve() {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any

--- a/apps/web-ui/src/components/dialogs/AddRegistryUrl.tsx
+++ b/apps/web-ui/src/components/dialogs/AddRegistryUrl.tsx
@@ -25,7 +25,7 @@ export function AddRegistryUrl({ open, onOpenChange, onNotify }: AddRegistryUrlP
       onNotify(`Registry ${url} added successfully`);
       setUrl('');
       onOpenChange(false);
-    } catch (error) {
+    } catch {
       onNotify('Failed to add registry', true);
     }
   };

--- a/docs/dockery-design.md
+++ b/docs/dockery-design.md
@@ -86,8 +86,8 @@ dockery/
 │   ├── dockery-design.md    ← 本文档
 │   ├── distribution-analysis.md
 │   └── GHCR_DEPLOYMENT.md
-├── docker-compose.yaml          生产参考
-├── docker-compose.dev.yaml      开发（registry 独立跑 :4999）
+├── docker-compose.dev.yaml      本地构建+运行整套（make dev）
+├── docker-compose.ghcr.yml      生产部署（拉取预构建镜像）
 ├── package.json                 pnpm workspace 根
 ├── pnpm-workspace.yaml
 ├── CLAUDE.md
@@ -595,7 +595,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 
 ### 10.1 环境变量
 
-**当前实际读取**（`cmd/api/main.go` + `docker-compose.yaml`）：
+**当前实际读取**（`cmd/api/main.go` + `docker-compose.ghcr.yml`）：
 
 | 变量 | 默认 | 说明 |
 |---|---|---|


### PR DESCRIPTION
## Summary

Follow-up to #22 (which shipped as v0.9.0).

- **Add a CI workflow** (`.github/workflows/ci.yml`) — runs on `pull_request` + pushes to `main`/`dev`. The only prior workflow fired on `v*` tags, so PRs reached `main` with **zero** automated checks. Jobs:
  - `web-ui`: `pnpm install --frozen-lockfile` → `lint` → `test` → `build`
  - `api`: `go build` → `go vet` → `make test`
- **Clear pre-existing lint debt** so the new lint gate is green from the start (all in files untouched by feature work):
  - eslint: scope `react-refresh/only-export-components` off for the generated `components/ui/**` dir (shadcn `cva()` `*Variants` co-exports — `allowConstantExport` doesn't cover call expressions).
  - `AddRegistryUrl`: drop the unused `catch` binding.
  - test setup: move a stale `eslint-disable` onto the actual `as any`.
- **Docs**: drop the now-deleted `docker-compose.yaml` references in the design doc (layout tree + env-vars source note).

## Verification (local)
- `pnpm lint` / `pnpm test` (23) / `pnpm build` — green.
- `go build ./...` / `go vet ./...` / `make test` — green.
- Both workflows validated with `actionlint` (incl. shellcheck).

## Not in this PR
- The CHANGELOG **0.8.0** backfill (0.8.0's release-time splice never landed; `--latest` won't backfill it). Best done on `main` via `git cliff v0.7.3..v0.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
