### PR TITLE
fix: 并发上限、注入与请求竞态加固

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -66,9 +66,15 @@ jobs:
 
       - name: Resolve release tag
         id: resolve
+        # inputs.tag goes through env (not ${{ }} inline in the script):
+        # inline interpolation happens before the shell runs, so a crafted
+        # input like `1.0.0$(…)` would be executed. Env indirection keeps
+        # it data. (The "Push git tag" step below already does the same.)
+        env:
+          RAW_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=v${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "tag=v$RAW_TAG" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi

--- a/apps/api/internal/service/registry.go
+++ b/apps/api/internal/service/registry.go
@@ -584,6 +584,13 @@ func (s *RegistryService) TagDetails(ctx *router.Context) error {
 
 	items := make([]TagDetail, len(tags))
 	sem := make(chan struct{}, tagDetailConcurrency)
+	// Separate pool for manifest-list child fetches. Without it, total
+	// upstream concurrency would be 12 × (entries per manifest list) —
+	// and the entry count is pusher-controlled. A distinct pool (NOT the
+	// outer sem: an outer goroutine holding a slot while its children
+	// wait on the same pool would deadlock once all slots are held by
+	// waiting parents) caps the whole request at 12 tags + 12 children.
+	childSem := make(chan struct{}, tagDetailConcurrency)
 	var wg sync.WaitGroup
 	for i, tag := range tags {
 		wg.Add(1)
@@ -591,7 +598,7 @@ func (s *RegistryService) TagDetails(ctx *router.Context) error {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			items[i] = s.buildTagDetail(ctx.Context(), name, tag)
+			items[i] = s.buildTagDetail(ctx.Context(), name, tag, childSem)
 		}(i, tag)
 	}
 	wg.Wait()
@@ -602,8 +609,9 @@ func (s *RegistryService) TagDetails(ctx *router.Context) error {
 // buildTagDetail resolves one tag to its TagDetail. Best-effort: a tag
 // whose manifest fetch fails comes back with just its name + zero size
 // (mirrors the frontend's prior per-tag fallback) so one bad tag never
-// fails the whole page.
-func (s *RegistryService) buildTagDetail(ctx context.Context, repo, tag string) TagDetail {
+// fails the whole page. childSem bounds the per-platform child fetches
+// across the whole request (see TagDetails).
+func (s *RegistryService) buildTagDetail(ctx context.Context, repo, tag string, childSem chan struct{}) TagDetail {
 	d := TagDetail{ImageName: repo, Tag: tag}
 	m, err := s.fetcher.Manifest(ctx, repo, tag)
 	if err != nil {
@@ -631,6 +639,8 @@ func (s *RegistryService) buildTagDetail(ctx context.Context, repo, tag string) 
 			wg.Add(1)
 			go func(i int, digest string) {
 				defer wg.Done()
+				childSem <- struct{}{}
+				defer func() { <-childSem }()
 				metas[i] = s.fetcher.ChildMeta(ctx, repo, digest)
 			}(i, e.Digest)
 		}

--- a/apps/api/internal/service/webhook.go
+++ b/apps/api/internal/service/webhook.go
@@ -135,7 +135,12 @@ func (s *WebhookService) Handle(ctx *router.Context) error {
 	// vendor type and 500s. The payload is plain JSON regardless of the
 	// header, so read and unmarshal it ourselves and stay
 	// content-type-agnostic.
-	body, err := io.ReadAll(ctx.Request().Body)
+	//
+	// LimitReader caps the buffered body — real distribution envelopes
+	// are a few KB, so 1 MiB is generous headroom while keeping a rogue
+	// loopback caller from forcing an arbitrary-size allocation. An
+	// oversized payload truncates and fails the Unmarshal below as a 400.
+	body, err := io.ReadAll(io.LimitReader(ctx.Request().Body, 1<<20))
 	if err != nil {
 		return response.ErrBadRequest.WithMessage("read request body")
 	}

--- a/apps/web-ui/src/hooks/use-current-user.ts
+++ b/apps/web-ui/src/hooks/use-current-user.ts
@@ -22,6 +22,10 @@ interface State {
  */
 export class CurrentUserViewModel extends ViewModelBase<State> {
   private bootstrapped = false;
+  // Request-sequence token (same pattern as CatalogViewModel): login()
+  // and logout() bump it so a still-in-flight /me from bootstrap can't
+  // land late and overwrite the fresher auth state.
+  private reqSeq = 0;
 
   protected $data(): State {
     return { user: null, loading: false, initialized: false };
@@ -36,11 +40,14 @@ export class CurrentUserViewModel extends ViewModelBase<State> {
   }
 
   async refresh(): Promise<void> {
+    const mySeq = ++this.reqSeq;
     this.data.loading = true;
     try {
       const user = await authService.me();
+      if (mySeq !== this.reqSeq) return;
       Object.assign(this.data, { user, loading: false, initialized: true });
     } catch (err) {
+      if (mySeq !== this.reqSeq) return;
       if (err instanceof ApiError && err.status === 401) {
         Object.assign(this.data, { user: null, loading: false, initialized: true });
         return;
@@ -52,6 +59,9 @@ export class CurrentUserViewModel extends ViewModelBase<State> {
 
   async login(username: string, password: string): Promise<void> {
     const user = await authService.login(username, password);
+    // Invalidate any in-flight /me so its (possibly 401) result can't
+    // overwrite the fresh login state.
+    this.reqSeq++;
     Object.assign(this.data, { user, initialized: true });
   }
 
@@ -59,6 +69,9 @@ export class CurrentUserViewModel extends ViewModelBase<State> {
     try {
       await authService.logout();
     } finally {
+      // Same invalidation in reverse: a stale /me must not resurrect
+      // the user after an explicit logout.
+      this.reqSeq++;
       this.data.user = null;
     }
   }


### PR DESCRIPTION
Code-review 修复，共 4 处：

- **ci**: `inputs.tag` 改走 `env` 传入 shell，消除 workflow_dispatch 脚本注入
- **registry**: TagDetails 的子 manifest 抓取加独立信号量，总并发封顶 12+12（原为 12 × 推送者可控的条目数）
- **webhook**: 请求体加 1 MiB 上限，超限按 400 处理
- **auth**: `/me` 加请求序号守卫，晚到的响应不再覆盖 login/logout 后的状态

验证：`go build/vet/test -race`、`tsc`、eslint、vitest 23/23、actionlint 全绿。
